### PR TITLE
Implement function constructors (Issue #23)

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -62,6 +62,17 @@ var createStringProperty = function(key) {
     return fluentStringFunction;
 };
 
+var createArrayProperty = function(key) {
+    var fluentArrayFunction = function(value) {
+        if (!(value instanceof Array)) {
+            value = [value];
+        }
+        this.node.Properties[key] = value;
+        return this;
+    };
+    return fluentArrayFunction;
+};
+
 var createReferenceProperty = function(key) {
     var fluentReferenceFunction = function(value) {
         if(typeof value === 'string') {
@@ -93,6 +104,7 @@ var createReferenceArrayProperty = function(key) {
 
 var propertyFunctionMap = {
     'string' : createStringProperty,
+    'array' : createArrayProperty,
     'reference' : createReferenceProperty,
     'referenceArray' : createReferenceArrayProperty
 };

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -51,4 +51,66 @@ Resource.prototype.deletionPolicy = function (policy) {
     return this;
 };
 
+///////////////////////////////////////////////////////////////////////////
+// -- Helper functions for keeping the code DRY and definitions small -- //
+///////////////////////////////////////////////////////////////////////////
+var createStringProperty = function(key) {
+    var fluentStringFunction = function(value) {
+        this.node.Properties[key] = value;
+        return this;
+    };
+    return fluentStringFunction;
+};
+
+var createReferenceProperty = function(key) {
+    var fluentReferenceFunction = function(value) {
+        if(typeof value === 'string') {
+            value = { 'Ref': value };
+        }
+        this.node.Properties[key] = value;
+        return this;
+    };
+    return fluentReferenceFunction;
+};
+
+var createReferenceArrayProperty = function(key) {
+    var fluentReferenceArrayFunction = function(arrayOfRefs) {
+        // If there's only one ref, encapsulate it in an array
+        if (!(arrayOfRefs instanceof Array)) {
+            arrayOfRefs = [arrayOfRefs];
+        }
+        // Automatically convert to references if the values are strings
+        for(var i=0; i<arrayOfRefs.length; i++){
+            if(typeof arrayOfRefs[i] === 'string'){
+                arrayOfRefs[i] = { 'Ref': arrayOfRefs[i] };
+            }
+        }
+        this.node.Properties[key] = arrayOfRefs;
+        return this;
+    };
+    return fluentReferenceArrayFunction;
+};
+
+var propertyFunctionMap = {
+    'string' : createStringProperty,
+    'reference' : createReferenceProperty,
+    'referenceArray' : createReferenceArrayProperty
+};
+
+Resource.registerPropertyPrototypes = function(klass, propertyMap){
+    for (var property in propertyMap) {
+        if (!propertyMap.hasOwnProperty(property)) {
+            continue;
+        }
+        var propertyType = propertyMap[property];
+        var func = propertyFunctionMap[propertyType];
+        if(!func) {
+            continue;
+        }
+        klass.prototype[property] = func(property.charAt(0).toUpperCase() + property.slice(1));
+    }
+    return klass;
+};
+
+
 module.exports = Resource;

--- a/lib/ec2/EIP.js
+++ b/lib/ec2/EIP.js
@@ -15,20 +15,14 @@
 'use strict';
 
 var Resource = require('../Resource.js');
-
+var propertyMap = {
+    'instanceId': 'string',
+    'domain': 'string'
+};
 var EIP = function (id, description) {
     return Resource.call(this, id, 'AWS::EC2::EIP', {});
 };
 require('util').inherits(EIP, Resource);
 
-EIP.prototype.instanceId = function(value) {
-   this.node.Properties.InstanceId = value;
-   return this;
-};
-
-EIP.prototype.domain = function(value) {
-   this.node.Properties.Domain = value;
-   return this;
-};
-
+EIP = Resource.registerPropertyPrototypes(EIP, propertyMap);
 module.exports = EIP;

--- a/lib/ec2/EIPAssociation.js
+++ b/lib/ec2/EIPAssociation.js
@@ -15,36 +15,18 @@
 'use strict';
 
 var Resource = require('../Resource.js');
+var propertyMap = {
+    'allocationId': 'string',
+    'eIP': 'string',
+    'instanceId': 'string',
+    'networkInterfaceId': 'string',
+    'privateIpAddress': 'string'
+};
 
 var EIPAssociation = function (id, description) {
     return Resource.call(this, id, 'AWS::EC2::EIPAssociation', {});
 };
 require('util').inherits(EIPAssociation, Resource);
-
-
-EIPAssociation.prototype.allocationId = function(value){
-    this.node.Properties.AllocationId = value;
-    return this;
-};
-
-EIPAssociation.prototype.eIP = function(value){
-    this.node.Properties.EIP = value;
-    return this;
-};
-
-EIPAssociation.prototype.instanceId = function(value){
-    this.node.Properties.InstanceId = value;
-    return this;
-};
-
-EIPAssociation.prototype.networkInterfaceId = function(value){
-    this.node.Properties.NetworkInterfaceId = value;
-    return this;
-};
-
-EIPAssociation.prototype.privateIpAddress = function(value){
-    this.node.Properties.PrivateIpAddress = value;
-    return this;
-};
+EIPAssociation = Resource.registerPropertyPrototypes(EIPAssociation, propertyMap);
 
 module.exports = EIPAssociation;

--- a/lib/ec2/Instance.js
+++ b/lib/ec2/Instance.js
@@ -28,57 +28,25 @@ var Instance = function (id, description) {
 
 require('util').inherits(Instance, Resource);
 
-Instance.prototype.keyName = function (keyName) {
-    this.node.Properties.KeyName = keyName;
-    return this;
+////////////////////////////////////////
+// -- Register property prototypes -- //
+////////////////////////////////////////
+var propertyMap = {
+    'keyName': 'string',
+    'imageId': 'string',
+    'instanceProfile': 'string',
+    'instanceType': 'string',
+    'securityGroups': 'referenceArray',
+    'subnetId': 'reference',
+    'userData': 'string'
 };
+Instance = Resource.registerPropertyPrototypes(Instance, propertyMap);
 
-Instance.prototype.imageId = function (imageId) {
-    this.node.Properties.ImageId = imageId;
-    return this;
-};
-
-Instance.prototype.instanceType = function (instanceType) {
-    this.node.Properties.InstanceType = instanceType;
-    return this;
-};
-
-Instance.prototype.instanceProfile = function (instanceProfile) {
-    this.node.Properties.IamInstanceProfile = instanceProfile;
-    return this;
-};
-
-Instance.prototype.securityGroups = function (securityGroups) {
-    if (!(securityGroups instanceof Array)) {
-        securityGroups = [securityGroups];
-    }
-
-    // Automatically convert to references if the values are strings
-    for(var i=0; i<securityGroups.length; i++){
-        if(typeof securityGroups[i] === 'string'){
-            securityGroups[i] = { 'Ref': securityGroups[i] };
-        }
-    }
-
-    this.node.Properties.SecurityGroups = securityGroups;
-    return this;
-};
-
+///////////////////////////////////////////////////
+// -- Special, additional property prototypes -- //
+///////////////////////////////////////////////////
 Instance.prototype.name = function (name) {
     this.node.Properties.Tags.push({'Key': 'Name', Value: name, 'PropagateAtLaunch': 'true'});
-    return this;
-};
-
-Instance.prototype.subnetId = function (subnetId) {
-    if(typeof subnetId === 'string'){
-        subnetId = { 'Ref': subnetId };
-    }
-    this.node.Properties.SubnetId = subnetId;
-    return this;
-};
-
-Instance.prototype.userData = function (userData) {
-    this.node.Properties.UserData = userData;
     return this;
 };
 

--- a/lib/ec2/InternetGateway.js
+++ b/lib/ec2/InternetGateway.js
@@ -15,19 +15,13 @@
 'use strict';
 
 var Resource = require('../Resource.js');
-
+var propertyMap = {
+    'tags': 'array'
+};
 var InternetGateway = function (id, description) {
     return Resource.call(this, id, 'AWS::EC2::InternetGateway', { Tags: [] });
 };
 
 require('util').inherits(InternetGateway, Resource);
-
-InternetGateway.prototype.tags = function(value) {
-    if (!(value instanceof Array)) {
-        value = [value];
-    }
-    this.node.Properties.Tags = value;
-    return this;
-};
-
+InternetGateway = Resource.registerPropertyPrototypes(InternetGateway, propertyMap);
 module.exports = InternetGateway;

--- a/lib/ec2/NetworkAcl.js
+++ b/lib/ec2/NetworkAcl.js
@@ -16,29 +16,18 @@
 
 var Resource = require('../Resource.js');
 var NetworkAclEntry = require('./NetworkAclEntry');
+var propertyMap = {
+    'tags': 'array',
+    'vpcId': 'reference'
+};
 
 var NetworkAcl = function (id, description, template) {
     return Resource.call(this, id, 'AWS::EC2::NetworkAcl', { Tags: [] }, template);
 };
 require('util').inherits(NetworkAcl, Resource);
+NetworkAcl = Resource.registerPropertyPrototypes(NetworkAcl, propertyMap);
 
-NetworkAcl.prototype.tags = function(value) {
-    if (!(value instanceof Array)) {
-        value = [value];
-    }
-    this.node.Properties.Tags = value;
-    return this;
-};
-
-NetworkAcl.prototype.vpcId = function(value) {
-    if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-
-    this.node.Properties.VpcId = value;
-    return this;
-};
-
+// -- Functions
 NetworkAcl.prototype.addAclEntry = function(id, description) {
     var acl = this.template.addResource(new NetworkAclEntry(id, description,this.template));
     acl.networkAclId(this.id);

--- a/lib/ec2/NetworkAclEntry.js
+++ b/lib/ec2/NetworkAclEntry.js
@@ -15,18 +15,24 @@
 'use strict';
 
 var Resource = require('../Resource.js');
+var propertyMap = {
+    'cidrBlock': 'string',
+    'icmp': 'string',
+    'networkAclId': 'reference',
+    'protocol': 'string',
+    'ruleAction': 'string',
+    'ruleNumber': 'string'
+};
 
 var NetworkAclEntry = function (id, description) {
     return Resource.call(this, id, 'AWS::EC2::NetworkAclEntry', {});
 };
 require('util').inherits(NetworkAclEntry, Resource);
 
-NetworkAclEntry.prototype.cidrBlock = function(value){
-    this.node.Properties.CidrBlock = value;
-    return this;
-};
+// -- Custom properties
+
 NetworkAclEntry.prototype.egress = function (value) {
-    if (value) { 
+    if (value) {
         this.node.Properties.Egress = value;
     } else {
         this.node.Properties.Egress = 'true';
@@ -39,27 +45,8 @@ NetworkAclEntry.prototype.ingress = function () {
     return this;
 };
 
-NetworkAclEntry.prototype.icmp = function(value){
-    this.node.Properties.Icmp = value;
-    return this;
-};
-
-NetworkAclEntry.prototype.networkAclId = function(value){
-    if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-
-    this.node.Properties.NetworkAclId = value;
-    return this;
-};
-
 NetworkAclEntry.prototype.portRange = function(from, to){
     this.node.Properties.PortRange = {From: from,To:to};
-    return this;
-};
-
-NetworkAclEntry.prototype.protocol = function(value){
-    this.node.Properties.Protocol = value;
     return this;
 };
 
@@ -70,12 +57,6 @@ NetworkAclEntry.prototype.tcp = function(from, to){
     return this;
 };
 
-
-NetworkAclEntry.prototype.ruleAction = function(value){
-    this.node.Properties.RuleAction = value;
-    return this;
-};
-
 NetworkAclEntry.prototype.allow = function(){
     this.node.Properties.RuleAction = 'allow';
     return this;
@@ -83,11 +64,6 @@ NetworkAclEntry.prototype.allow = function(){
 
 NetworkAclEntry.prototype.deny = function () {
     this.node.Properties.RuleAction = 'deny';
-    return this;
-};
-
-NetworkAclEntry.prototype.ruleNumber = function(value){
-    this.node.Properties.RuleNumber = value;
     return this;
 };
 

--- a/lib/ec2/Route.js
+++ b/lib/ec2/Route.js
@@ -15,63 +15,18 @@
 'use strict';
 
 var Resource = require('../Resource.js');
-
+var propertyMap = {
+    'destinationCidrBlock': 'string',
+    'gatewayId': 'reference',
+    'instanceId': 'reference',
+    'networkInterfaceId': 'reference',
+    'routeTableId': 'reference',
+    'vpcPeeringConnectionId': 'reference'
+};
 var Route = function (id, description, template) {
     return Resource.call(this, id, 'AWS::EC2::Route', {}, template);
 };
 require('util').inherits(Route, Resource);
-
-Route.prototype.destinationCidrBlock = function(value){
-    this.node.Properties.DestinationCidrBlock = value;
-    return this;
-};
-
-Route.prototype.gatewayId = function(value){
-    if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-
-    this.node.Properties.GatewayId = value;
-    return this;
-};
-
-Route.prototype.instanceId = function(value){
-    this.node.Properties.InstanceId = value;
-    if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-
-    this.node.Properties.InstanceId = value;
-    return this;
-};
-
-Route.prototype.networkInterfaceId = function(value){
-    this.node.Properties.NetworkInterfaceId = value;
-    if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-
-    this.node.Properties.NetworkInterfaceId = value;
-    return this;
-};
-
-Route.prototype.routeTableId = function(value){
-    this.node.Properties.RouteTableId = value;
-    if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-
-    this.node.Properties.RouteTableId = value;
-    return this;
-};
-
-Route.prototype.vpcPeeringConnectionId = function(value){
-    if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-
-    this.node.Properties.VpcPeeringConnectionId = value;
-    return this;
-};
+Route = Resource.registerPropertyPrototypes(Route, propertyMap);
 
 module.exports = Route;

--- a/lib/ec2/RouteTable.js
+++ b/lib/ec2/RouteTable.js
@@ -16,29 +16,18 @@
 
 var Resource = require('../Resource.js');
 var Route = require('./Route.js');
+var propertyMap = {
+    'tags': 'array',
+    'vpcId': 'reference'
+};
 
 var RouteTable = function (id, description, template) {
     return Resource.call(this, id, 'AWS::EC2::RouteTable', { Tags: [{ Key: 'Description', Value: description}] }, template);
 };
 require('util').inherits(RouteTable, Resource);
+RouteTable = Resource.registerPropertyPrototypes(RouteTable, propertyMap);
 
-RouteTable.prototype.tags = function(value) {
-    if (!(value instanceof Array)) {
-        value = [value];
-    }
-    this.node.Properties.Tags = value;
-    return this;
-};
-
-RouteTable.prototype.vpcId = function(value) {
-        if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-
-    this.node.Properties.VpcId = value;
-    return this;
-};
-
+// -- Functions
 RouteTable.prototype.addRoute = function(id, description) {
     var r = this.template.addResource(new Route(id, description,this.template));
     r.routeTableId(this.id);

--- a/lib/ec2/SecurityGroup.js
+++ b/lib/ec2/SecurityGroup.js
@@ -15,27 +15,17 @@
 'use strict';
 
 var Resource = require('../Resource.js');
-
+var propertyMap = {
+    'vpcId': 'reference',
+    'tags': 'array'
+};
 var SecurityGroup = function (id, description) {
     Resource.call(this, id, 'AWS::EC2::SecurityGroup');
     this.node.Properties.GroupDescription = description;
     return this;
 };
-
 require('util').inherits(SecurityGroup, Resource);
-
-SecurityGroup.prototype.vpcId = function (value) {
-    this.node.Properties.VpcId = value;
-    return this;
-};
-
-SecurityGroup.prototype.tags = function (tags) {
-    if (!(tags instanceof Array)) {
-        tags = [ tags];
-    }
-    this.node.Properties.Tags = tags;
-    return this;
-};
+SecurityGroup = Resource.registerPropertyPrototypes(SecurityGroup, propertyMap);
 
 SecurityGroup.prototype.tcpIn = function (properties) {
     var args = Array.prototype.slice.call(arguments, 1);

--- a/lib/ec2/Subnet.js
+++ b/lib/ec2/Subnet.js
@@ -15,39 +15,17 @@
 'use strict';
 
 var Resource = require('../Resource.js');
+var propertyMap = {
+    'availabilityZone': 'string',
+    'cidrBlock': 'string',
+    'tags': 'array',
+    'vpcId': 'reference'
+};
 
 var Subnet = function (id, description) {
     return Resource.call(this, id, 'AWS::EC2::Subnet', { Tags: [{Key:'Description', Value:description}] });
 };
 
 require('util').inherits(Subnet, Resource);
-
-Subnet.prototype.availabilityZone = function(value) {
-    this.node.Properties.AvailabilityZone = value;
-    return this;
-};
-
-Subnet.prototype.cidrBlock = function(value) {
-    this.node.Properties.CidrBlock = value;
-    return this;
-};
-
-Subnet.prototype.tags = function(value) {
-    if (!(value instanceof Array)) {
-        value = [value];
-    }
-    this.node.Properties.Tags = value;
-    return this;
-};
-
-Subnet.prototype.vpcId = function(value) {
-    // Automatically convert to reference if the value is string
-    if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-
-    this.node.Properties.VpcId = value;
-    return this;
-};
-
+Subnet = Resource.registerPropertyPrototypes(Subnet, propertyMap);
 module.exports = Subnet;

--- a/lib/ec2/SubnetNetworkAclAssociation.js
+++ b/lib/ec2/SubnetNetworkAclAssociation.js
@@ -15,28 +15,16 @@
 'use strict';
 
 var Resource = require('../Resource.js');
+var propertyMap = {
+    'networkAclId': 'reference',
+    'subnetId': 'reference'
+};
 
 var SubnetNetworkAclAssociation = function (id, description) {
     return Resource.call(this, id, 'AWS::EC2::SubnetNetworkAclAssociation', {});
 };
+
 require('util').inherits(SubnetNetworkAclAssociation, Resource);
-
-SubnetNetworkAclAssociation.prototype.subnetId = function(value) {
-    if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-
-    this.node.Properties.SubnetId = value;
-    return this;
-};
-
-SubnetNetworkAclAssociation.prototype.networkAclId = function(value) {
-    if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-
-    this.node.Properties.NetworkAclId = value;
-    return this;
-};
+SubnetNetworkAclAssociation = Resource.registerPropertyPrototypes(SubnetNetworkAclAssociation, propertyMap);
 
 module.exports = SubnetNetworkAclAssociation;

--- a/lib/ec2/SubnetRouteTableAssociation.js
+++ b/lib/ec2/SubnetRouteTableAssociation.js
@@ -15,26 +15,15 @@
 'use strict';
 
 var Resource = require('../Resource.js');
+var propertyMap = {
+    'routeTableId': 'reference',
+    'subnetId': 'reference'
+};
 
 var SubnetRouteTableAssociation = function (id, description) {
     return Resource.call(this, id, 'AWS::EC2::SubnetRouteTableAssociation', {});
 };
 require('util').inherits(SubnetRouteTableAssociation, Resource);
-
-SubnetRouteTableAssociation.prototype.routeTableId = function(value) {
-    if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-    this.node.Properties.RouteTableId = value;
-    return this;
-};
-
-SubnetRouteTableAssociation.prototype.subnetId = function(value) {
-    if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-    this.node.Properties.SubnetId = value;
-    return this;
-};
+SubnetRouteTableAssociation = Resource.registerPropertyPrototypes(SubnetRouteTableAssociation, propertyMap);
 
 module.exports = SubnetRouteTableAssociation;

--- a/lib/ec2/VPC.js
+++ b/lib/ec2/VPC.js
@@ -19,6 +19,13 @@ var Subnet = require('./Subnet.js');
 var RouteTable = require('./RouteTable');
 var NetworkAcl = require('./NetworkAcl');
 
+var propertyMap = {
+    'cidrBlock': 'string',
+    'enableDnsSupport': 'string',
+    'enableDnsHostnames': 'string',
+    'instanceTenancy': 'string',
+    'tags': 'array'
+};
 var VPC = function (id, description, cidrBlock, template) {
     
 
@@ -28,36 +35,9 @@ var VPC = function (id, description, cidrBlock, template) {
 };
 
 require('util').inherits(VPC, Resource);
+VPC = Resource.registerPropertyPrototypes(VPC, propertyMap);
 
-VPC.prototype.cidrBlock = function(value) {
-    this.node.Properties.CidrBlock = value;
-    return this;
-};
-
-VPC.prototype.enableDnsSupport = function(value) {
-    this.node.Properties.EnableDnsSupport = value;
-    return this;
-};
-
-VPC.prototype.enableDnsHostnames = function(value) {
-    this.node.Properties.EnableDnsHostnames = value;
-    return this;
-};
-
-VPC.prototype.instanceTenancy = function(value) {
-    this.node.Properties.InstanceTenancy = value;
-    return this;
-};
-
-VPC.prototype.tags = function(value) {
-    if (!(value instanceof Array)) {
-        value = [value];
-    }
-    this.node.Properties.Tags = value;
-    return this;
-};
-
-
+// VPC-specific functions
 VPC.prototype.addSubnet = function (id, description) {
     var sub = this.template.addResource(new Subnet(id, description, this.template));
     sub.vpcId(this.id);

--- a/lib/ec2/VPCGatewayAttachment.js
+++ b/lib/ec2/VPCGatewayAttachment.js
@@ -15,36 +15,17 @@
 'use strict';
 
 var Resource = require('../Resource.js');
+var propertyMap = {
+    'internetGatewayId': 'reference',
+    'vpcId': 'reference',
+    'vpnGatewayId': 'reference'
+};
 
 var VPCGatewayAttachment = function (id, description) {
     return Resource.call(this, id, 'AWS::EC2::VPCGatewayAttachment');
 };
 
 require('util').inherits(VPCGatewayAttachment, Resource);
-
-VPCGatewayAttachment.prototype.internetGatewayId = function(value) {
-    if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-
-    this.node.Properties.InternetGatewayId = value;
-    return this;
-};
-
-VPCGatewayAttachment.prototype.vpcId = function(value) {
-    if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-    this.node.Properties.VpcId = value;
-    return this;
-};
-
-VPCGatewayAttachment.prototype.vpnGatewayId = function(value) {
-    if(typeof value === 'string'){
-        value = { 'Ref': value };
-    }
-    this.node.Properties.VpnGatewayId = value;
-    return this;
-};
+VPCGatewayAttachment = Resource.registerPropertyPrototypes(VPCGatewayAttachment, propertyMap);
 
 module.exports = VPCGatewayAttachment;


### PR DESCRIPTION
This commit simplifies the creation of AWS resource files by drastically reducing the amount of code required to define properties for each resource type.

Previously, every property needed an explicit function defined that look nearly identical to almost every other function. This is not DRY! Now, we just define our properties and their types in an object, and register them.

## Before (yuck!)
```javascript
Instance.prototype.instanceProfile = function (instanceProfile) {
    this.node.Properties.IamInstanceProfile = instanceProfile;
    return this;
};

Instance.prototype.securityGroups = function (securityGroups) {
    if (!(securityGroups instanceof Array)) {
        securityGroups = [securityGroups];
    }

    // Automatically convert to references if the values are strings
    for(var i=0; i<securityGroups.length; i++){
        if(typeof securityGroups[i] === 'string'){
            securityGroups[i] = { 'Ref': securityGroups[i] };
        }
    }

    this.node.Properties.SecurityGroups = securityGroups;
    return this;
};
```

## After (wow!)
```javascript
var propertyMap = {
    'instanceProfile': 'string',
    'securityGroups': 'referenceArray'
};
Instance = Resource.registerPropertyPrototypes(Instance, propertyMap);
```

Currently, all of the EC2 resources have been converted to use this new format. The rest are forthcoming.
We have function constructors for 4 property types right now:

+ String
+ Array
+ Reference
+ ReferenceArray

We will continue to implement these as we begin to expand this new paradigm to the rest of the codebase.