### PR TITLE
Add 'Referencable' class and associated unit tests

### DIFF
--- a/lib/Referencable.js
+++ b/lib/Referencable.js
@@ -1,0 +1,23 @@
+// Copyright 2014 OpenWhere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+function Referencable (){ }
+
+Referencable.prototype.ref = function() {
+    return { 'Ref': this.id };
+};
+
+module.exports = Referencable;

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -15,6 +15,8 @@
 'use strict';
 
 var _ = require('lodash');
+var util = require('util');
+var Referencable = require('./Referencable.js');
 
 function Resource(id, type, properties, template) {
     this.template = template;
@@ -30,9 +32,7 @@ function Resource(id, type, properties, template) {
     return this;
 }
 
-Resource.prototype.ref = function () {
-    return { 'Ref': this.id };
-};
+util.inherits(Resource, Referencable);
 
 Resource.prototype.getAtt = function (att) {
     return { 'Fn::GetAtt': [ this.id , att ]};

--- a/lib/ec2/Instance.js
+++ b/lib/ec2/Instance.js
@@ -18,10 +18,6 @@ var Resource = require('../Resource.js');
 var fs = require('fs');
 var Handlebars = require('handlebars');
 
-Handlebars.registerHelper('stringify', function (obj) {
-    return new Handlebars.SafeString(JSON.stringify(obj));
-});
-
 var Instance = function (id) {
     return Resource.call(this, id, 'AWS::EC2::Instance', { Tags: [] });
 };

--- a/test/referencable_test.js
+++ b/test/referencable_test.js
@@ -1,0 +1,37 @@
+// Copyright 2014 OpenWhere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var Instance = require ('../lib/ec2/Instance.js');
+var Referencable = require ('../lib/Referencable.js');
+var _ = require('lodash');
+
+exports.referencableTypeTest = function(test){
+    var myInstance = new Instance();
+
+    test.expect(1);
+    test.ok(myInstance instanceof Referencable);
+    test.done();
+};
+
+exports.canReferenceTest = function(test){
+    var instanceId = 'testId123';
+    var myInstance = new Instance(instanceId);
+    var myReference = myInstance.ref();
+
+    test.expect(1);
+    test.ok( _.isEqual({ 'Ref': instanceId }, myReference) );
+    test.done();
+};


### PR DESCRIPTION
This class will be used when creating property functions. We'll be able to check if the object passed in is an instance of `Referencable`, and if it is, invoke the `ref()` function on the object for the property.