### PR TITLE
Reference objs can now be to string fields (because they will evaluate to strings)

### DIFF
--- a/lib/AWSClass.js
+++ b/lib/AWSClass.js
@@ -38,6 +38,11 @@ function InvalidPropertyException(message) {
 AWSClass.InvalidPropertyException = InvalidPropertyException;
 
 function checkPrimitiveType(key, value, propertyType) {
+    // References will evaluate to strings, so it'll be ok!
+    if(propertyType === 'string' && typeof value === 'object' && value.Ref){
+        return true;
+    }
+    // Everything that's not okay, let's throw a helpful error
     if(typeof value !== propertyType){
         throw new InvalidPropertyException('Invalid value passed to ' + key +
             '. Expected type ' + propertyType + ' but was ' + (typeof value));
@@ -46,6 +51,7 @@ function checkPrimitiveType(key, value, propertyType) {
 }
 
 function checkObjectType(key, value, propertyType) {
+    // Catch errors for all the other nasty things
     if(!(value instanceof propertyType)){
         throw new InvalidPropertyException('Invalid value passed to ' + key +
             '. Please ensure the object passed is an instance of ' + propertyType);
@@ -67,7 +73,7 @@ var createPropertyFunction = function(key, isList, propertyType) {
                 if(typeof propertyType === 'string'){
                     checkPrimitiveType(key, value[i], propertyType);
                 }
-                else if(typeof propertyType === 'function') {
+                else if(typeof propertyType === 'function' || typeof propertyType === 'object') {
                     checkObjectType(key, value[i], propertyType);
                 }
                 else {
@@ -80,7 +86,7 @@ var createPropertyFunction = function(key, isList, propertyType) {
             if(typeof propertyType === 'string'){
                 checkPrimitiveType(key, value, propertyType);
             }
-            else if(typeof propertyType === 'function') {
+            else if(typeof propertyType === 'function' || typeof propertyType === 'object') {
                 checkObjectType(key, value, propertyType);
             }
         }
@@ -94,7 +100,7 @@ var createPropertyFunction = function(key, isList, propertyType) {
             } else {
                 this.node[key] = value;
             }
-        } 
+        }
         // Resources and their subclasses DO have a properties key in their node
         else {
             if(value instanceof Referencable) {

--- a/test/templateStrParamsTest.js
+++ b/test/templateStrParamsTest.js
@@ -1,0 +1,14 @@
+'use strict';
+
+exports.TemplateStrParamsTest = function(test) {
+    var Scenery = require('../Scenery.js');
+    var t = new Scenery.Template();
+    t.strParam('CidrBlock', '10.0.0.0/16', 'The CIDR block you want the VPC to cover');
+    var myVpcId = 'TestVPC';
+
+    test.expect(1);
+    test.doesNotThrow(function(){
+        var vpc = t.vpc(myVpcId).CidrBlock( t.ref('CidrBlock') ).EnableDnsHostnames(true);
+    });
+    test.done();
+};


### PR DESCRIPTION
This fixes GitHub issue #40

The new test added asserts that the error that Andy was getting is now resolved.