### PR TITLE
Resolve issue #52: Ref vs. ref

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,7 +20,8 @@ module.exports = function(grunt) {
             all: [
                 'test/**/*_test.js',
                 'test/**/*Test.js',
-                '!test/ignore/*'
+                '!test/ignore/*',
+                '!test/landscapes/*'
             ]
         },
         jshint: {

--- a/lib/AWSClass.js
+++ b/lib/AWSClass.js
@@ -44,7 +44,7 @@ AWSClass.InvalidPropertyException = InvalidPropertyException;
 
 function checkPrimitiveType(key, value, propertyType) {
     // References will evaluate to strings, so it'll be ok!
-    if(propertyType === 'string' && typeof value === 'object' && value.Ref){
+    if(propertyType === 'string' && typeof value === 'object' && (value.ref || value.Ref) ){
         return true;
     }
     // Everything that's not okay, let's throw a helpful error

--- a/test/iam_from_template_test.js
+++ b/test/iam_from_template_test.js
@@ -19,7 +19,7 @@
 // cloudformation templates.
 
 var Template = require('../lib/Template.js');
-var Role = require('../lib/iam/Role.js');
+var Role = require('../lib/IAM/Role.js');
 var path = require('path');
 
 var originalPath = path.join(__dirname, 'landscapes', 'VPC.json');

--- a/test/referencableStringsTest.js
+++ b/test/referencableStringsTest.js
@@ -1,0 +1,17 @@
+'use strict';
+
+exports.TemplateReferencableStringsTest = function(test) {
+    var Scenery = require('../scenery.js');
+    var Referencable = require('../lib/Referencable.js');
+    var t = new Scenery.Template();
+    var myVpcId = 'testVpcId';
+    var myGateway = t.internetGateway(myVpcId+'gateway');
+    var internetGatewayAttachment = t.vpcGatewayAttachment(myVpcId+'InternetGateWayAttachment');
+    
+    test.expect(2);
+    test.ok(myGateway instanceof Referencable);
+    test.doesNotThrow(function(){
+        internetGatewayAttachment.InternetGatewayId(myGateway).VpcId(myVpcId); 
+    });
+    test.done();
+};

--- a/test/templateStrParamsTest.js
+++ b/test/templateStrParamsTest.js
@@ -1,7 +1,7 @@
 'use strict';
 
 exports.TemplateStrParamsTest = function(test) {
-    var Scenery = require('../Scenery.js');
+    var Scenery = require('../scenery.js');
     var t = new Scenery.Template();
     t.strParam('CidrBlock', '10.0.0.0/16', 'The CIDR block you want the VPC to cover');
     var myVpcId = 'TestVPC';


### PR DESCRIPTION
The issue was that sometimes we're passing a referencable object (that has a `ref()` function), and sometimes we're passing an object that has a `'Ref'` key.  Both of these are valid, so we must allow both to be accepted.

Bonus: fixed a couple capitalization errors.