### PR TITLE
Ability to extend base Resource classes with convenience functions 

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -34,8 +34,21 @@ function Resource(id, type, properties, template) {
     if (properties) {
         _.extend(this.node.Properties, properties);
     }
+    
+    // If we have convenience functions with which to extend this class, install them
+    var ConvenienceClass = null;
+    try {
+        if(type) {
+            ConvenienceClass = require('./convenience/' + type + '.js');
+            _.mixin(this, new ConvenienceClass());
+        }
+    } catch (e){
+        //console.log('Failed to find convenience class for', type, e);
+    }
+
     return this;
 }
+
 
 modelo.inherits(Resource, Referencable, AWSClass);
 

--- a/lib/convenience/AWS::EC2::VPC.js
+++ b/lib/convenience/AWS::EC2::VPC.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var NetworkAcl = require('../EC2/NetworkAcl.js');
+var RouteTable = require('../EC2/RouteTable.js');
+var Subnet = require('../EC2/Subnet.js');
+
+function VPC (){ }
+
+VPC.prototype.addSubnet = function (subnetId, description) {
+    if(!this.template) {
+        throw 'Cannot addSubnet: VPC does not belong to a template yet';
+    }
+    var sub = this.template.addResource( new Subnet(subnetId, {}, description, this.template) );
+    sub.VpcId(this.id);
+    return sub;
+};
+
+VPC.prototype.addRouteTable = function (rtid, description) {
+    if(!this.template) {
+        throw 'Cannot addRouteTable: VPC does not belong to a template yet';
+    }
+    var rt = this.template.addResource(new RouteTable(rtid, {}, description, this.template));
+    rt.VpcId(this.id);
+    return rt;
+};
+
+VPC.prototype.addNetworkAcl = function (aclId, description) {
+    if(!this.template) {
+        throw 'Cannot addNetworkAcl: VPC does not belong to a template yet';
+    }
+    var nacl = this.template.addResource(new NetworkAcl(aclId, {}, description, this.template));
+    nacl.VpcId(this.id);
+    return nacl;
+};
+
+module.exports = VPC;

--- a/lib/convenience/AWS::EC2::VPC.js
+++ b/lib/convenience/AWS::EC2::VPC.js
@@ -6,31 +6,46 @@ var Subnet = require('../EC2/Subnet.js');
 
 function VPC (){ }
 
-VPC.prototype.addSubnet = function (subnetId, description) {
-    if(!this.template) {
-        throw 'Cannot addSubnet: VPC does not belong to a template yet';
+VPC.prototype.addSubnet = function (template, subnetId, cidrBlock, tags) {
+    if(!template) {
+        throw 'Cannot addSubnet: No template provided';
     }
-    var sub = this.template.addResource( new Subnet(subnetId, {}, description, this.template) );
-    sub.VpcId(this.id);
-    return sub;
+    var sub = new Subnet(subnetId);
+    if(cidrBlock){
+        sub.CidrBlock(cidrBlock);
+    }
+    if(tags){
+        sub.Tags(tags);
+    }
+    sub.VpcId(this);
+    template.addResource(sub);
+    return this;
 };
 
-VPC.prototype.addRouteTable = function (rtid, description) {
-    if(!this.template) {
-        throw 'Cannot addRouteTable: VPC does not belong to a template yet';
+VPC.prototype.addRouteTable = function (rtid, template, tags) {
+    if(!template) {
+        throw 'Cannot addRouteTable: No template provided';
     }
-    var rt = this.template.addResource(new RouteTable(rtid, {}, description, this.template));
-    rt.VpcId(this.id);
-    return rt;
+    var rt = new RouteTable(rtid);
+    if(tags){
+        rt.Tags(tags);
+    }
+    rt.VpcId(this);
+    template.addResource(rt);
+    return this;
 };
 
-VPC.prototype.addNetworkAcl = function (aclId, description) {
-    if(!this.template) {
-        throw 'Cannot addNetworkAcl: VPC does not belong to a template yet';
+VPC.prototype.addNetworkAcl = function (aclId, template, tags) {
+    if(!template) {
+        throw 'Cannot addNetworkAcl: No template provided';
     }
-    var nacl = this.template.addResource(new NetworkAcl(aclId, {}, description, this.template));
-    nacl.VpcId(this.id);
-    return nacl;
+    var nacl = new NetworkAcl(aclId);
+    if(tags){
+        nacl.Tags(tags);
+    }
+    nacl.VpcId(this);
+    template.addResource(nacl);
+    return this;
 };
 
 module.exports = VPC;

--- a/test/convenienceFunctionsTest.js
+++ b/test/convenienceFunctionsTest.js
@@ -1,0 +1,25 @@
+'use strict';
+
+exports.testConvenienceFunctionsExist = function(test) {
+    var VPC = require('../lib/EC2/VPC.js');
+    var Template = require('../lib/Template.js');
+    var myVPC = new VPC();
+    
+    test.expect(5);
+    
+    // Check to make sure functions from the AWS Documentation exist
+    test.ok(myVPC.EnableDnsHostnames);
+    
+    // Check to make sure our convenience functions exist
+    test.ok(myVPC.addSubnet);
+   
+    // Assert our convenience function works in standard conditions
+    test.doesNotThrow(function() {
+        var t = new Template();
+        var myTestVpc = new VPC('vpcLogicalId').addSubnet(t, 'myTestSubnet', '10.0.0.0/8');
+        t.addResource(myTestVpc);
+        test.deepEqual(t.template.Resources.myTestSubnet.Properties.VpcId, {Ref: 'vpcLogicalId'});
+        test.ok(t.template.Resources.myTestSubnet.Properties.CidrBlock === '10.0.0.0/8');
+    });
+    test.done();
+};


### PR DESCRIPTION
This addresses Issue #53, and implements 3 convenience functions for the `AWS::EC2::VPC` class. Unit tests are, of course, included.