### PR TITLE
Refactor how values are added to the template

### DIFF
--- a/lib/AWSClass.js
+++ b/lib/AWSClass.js
@@ -17,7 +17,7 @@
 var _ = require('lodash');
 var Referencable = require('./Referencable.js');
 
-function AWSClass(id, type, properties, template) {
+function AWSClass(id, type, properties) {
     // Check to ensure we only have valid alphaneumeric characters in our ID
     if(! /^[a-z0-9]+$/i.test(id)) {
         throw 'Logical IDs must be alphaneumeric; please edit: ' + id;
@@ -25,7 +25,6 @@ function AWSClass(id, type, properties, template) {
 
     this.id = id;
     this.type = type;
-    this.template = template;
     this.node = {};
     if (properties) {
         _.extend(this.node, properties);
@@ -64,6 +63,18 @@ function checkObjectType(key, value, propertyType) {
     return true;
 }
 
+function getValueToAppendToTemplate(value) {
+    if(value instanceof Referencable || value.ref) {
+        return value.ref();
+    } else if(value.Ref) {      // Is a reference object: { Ref: 'logicalId' }
+        return value;
+    } else if (value.node) {    // Is a typed property -- get its node contents
+        return value.node;
+    } else {                    // Is a primitive
+        return value;
+    }
+}
+
 var createPropertyFunction = function(key, isList, propertyType) {
     var fluentFunction = function(value) {
 
@@ -73,8 +84,9 @@ var createPropertyFunction = function(key, isList, propertyType) {
                 typeof propertyType);
         }
 
-        if(isList) {
-            for(var i=value.length-1; i > -1; i--){
+        if(isList && value instanceof Array) {
+            var i = value.length - 1;
+            for(i; i>-1; i--){
                 if(typeof propertyType === 'string'){
                     checkPrimitiveType(key, value[i], propertyType);
                 }
@@ -98,20 +110,29 @@ var createPropertyFunction = function(key, isList, propertyType) {
 
         // All validations pass; add the value to the document
 
-        // Properties don't have a "Properties" key in their node
-        if(this instanceof AWSClass && !(this.node.Properties)){
-            if(value instanceof Referencable) {
-                this.node[key] = value.ref();
-            } else {
-                this.node[key] = value;
+        if(isList && value instanceof Array){
+            // If we receive a list of values, we must transform every one
+            var j = value.length - 1;
+            var newList = [];
+            for(j; j>-1; j--){
+                newList.push( getValueToAppendToTemplate(value[j]) );
             }
-        }
-        // Resources and their subclasses DO have a properties key in their node
-        else {
-            if(value instanceof Referencable) {
-                this.node.Properties[key] = value.ref();
-            } else {
-                this.node.Properties[key] = value;
+            // Properties don't have a "Properties" key in their node
+            if(this instanceof AWSClass && !(this.node.Properties)){
+                this.node[key] = newList;
+            }
+            // Resources and their subclasses DO have a properties key in their node
+            else {
+                this.node.Properties[key] = newList;
+            }
+        } else {
+            // Properties don't have a "Properties" key in their node
+            if(this instanceof AWSClass && !(this.node.Properties)){
+                this.node[key] = getValueToAppendToTemplate(value);
+            }
+            // Resources and their subclasses DO have a properties key in their node
+            else {
+                this.node.Properties[key] = getValueToAppendToTemplate(value);
             }
         }
         return this;

--- a/test/resource_test.js
+++ b/test/resource_test.js
@@ -104,22 +104,45 @@ exports.testCanAddPropertyTypes = function(test) {
     var attDef = new AttributeDefinition('asdf').AttributeName('testName').AttributeType('testType');
     var table = new Table('myTestTable').AttributeDefinitions([ attDef ]);
     t.addResource(table);
-    
+
     // Make sure we only get the "node" of the property types
     test.expect(2);
     test.ok(t.template.Resources.myTestTable.Properties.AttributeDefinitions);
     test.deepEqual(
-        attDef.node, 
+        attDef.node,
         t.template.Resources.myTestTable.Properties.AttributeDefinitions[0]
     );
     test.done();
 };
 
-exports.testShouldFailNoArray = function(test) {
-   test.done(); 
+exports.testShouldFailIfNoArray = function(test) {
+    test.expect(1);
+    test.throws(function(){
+        var attDef = new AttributeDefinition('asdf').AttributeName('testName').AttributeType('testType');
+        // We should error if we try to add attDef by itself, instead of as an array member
+        var table = new Table('myTestTable').AttributeDefinitions( attDef );
+    });
+    test.done();
 };
 
 exports.testCanAddReferenceTypes = function(test) {
+    var Instance = require('../lib/EC2/Instance.js');
+    var SecurityGroup = require('../lib/EC2/SecurityGroup.js');
     var t = new Template();
+    var i = new Instance('myFantasticTestInstance');
+    var sg = new SecurityGroup('myMostExcellentSecurityGroup');
+    var expectedRefObj = { Ref: 'myMostExcellentSecurityGroup' };
+
+    i.SecurityGroupIds([sg]);
+    t.addResource(i);
+    t.addResource(sg);
+
+    test.expect(2);
+    test.ok(t.template.Resources);
+    test.deepEqual(
+        expectedRefObj,
+        t.template.Resources.myFantasticTestInstance.Properties.SecurityGroupIds[0]
+    );
+
     test.done();
 };

--- a/test/resource_test.js
+++ b/test/resource_test.js
@@ -17,6 +17,8 @@
 var _ = require('lodash');
 var AWSClass = require('../lib/AWSClass.js');
 var Resource = require('../lib/Resource.js');
+var Table = require('../lib/DynamoDB/Table.js');
+var Template = require('../lib/Template.js');
 var AttributeDefinition = require('../lib/properties/DynamodbAttributedef.js');
 
 exports.registerPropertyPrototypesTest = function(test){
@@ -94,5 +96,30 @@ exports.registerPropertyPrototypesTest = function(test){
     }, 'Issue adding properties to the document');
 
     // All done!
+    test.done();
+};
+
+exports.testCanAddPropertyTypes = function(test) {
+    var t = new Template();
+    var attDef = new AttributeDefinition('asdf').AttributeName('testName').AttributeType('testType');
+    var table = new Table('myTestTable').AttributeDefinitions([ attDef ]);
+    t.addResource(table);
+    
+    // Make sure we only get the "node" of the property types
+    test.expect(2);
+    test.ok(t.template.Resources.myTestTable.Properties.AttributeDefinitions);
+    test.deepEqual(
+        attDef.node, 
+        t.template.Resources.myTestTable.Properties.AttributeDefinitions[0]
+    );
+    test.done();
+};
+
+exports.testShouldFailNoArray = function(test) {
+   test.done(); 
+};
+
+exports.testCanAddReferenceTypes = function(test) {
+    var t = new Template();
     test.done();
 };

--- a/test/resource_test.js
+++ b/test/resource_test.js
@@ -17,7 +17,7 @@
 var _ = require('lodash');
 var AWSClass = require('../lib/AWSClass.js');
 var Resource = require('../lib/Resource.js');
-var AttributeDefinition = require('../lib/properties/AttributeDefinition.js');
+var AttributeDefinition = require('../lib/properties/DynamodbAttributedef.js');
 
 exports.registerPropertyPrototypesTest = function(test){
     // Set up the class to extend Resource


### PR DESCRIPTION
This pull request fixes issues #58 and #59.

There are three big fixes in here, all of which occur between lines 66 and 135 in AWSClass.  Then, of course, there are unit tests to assert our fixes.

# The fixes:
1. First, we fixed how Scenery objects are added to the template.  Rather than add the whole Scenery object, we only care about the contents of the `.node` property. Super duper.
2. Next, we fixed/added the ability to add referencable objects to the template. For example, SecurityGroupIds expects an array of strings, but you can pass it an array of SecurityGroup objects, and they will evaluate themselves to be references to their logical Ids.  Neat!
3. Finally, none of these conversions were happening for arrays. Now, we will loop through all the contents of an array and property prune/cast their contents before adding to the template. Great!