### PR TITLE
Update README and add examples folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 # Scenery: CloudFormation Templates in Javascript
+Scenery aims to simplify the creation of CloudFormation templates by using
+Javascript to generate them. This makes loops, variables, conditional logic, and
+convenience functions available for template generation, significantly reducing
+the number of lines needed while improving consistency throughout templates.
+
+The entire [AWS CloudFormation API](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-reference.html)
+is available for use in Scenery, thanks to the [Scenery Generator](https://github.com/OpenWhere/scenery_generator)
+project, which generates Scenery classes from the Cloudformation docs.
+
+Please see the [examples](#TODO) folder for sample Scenery templates and the
+resulting CloudFormation template.
 
 ## Setup
-+ Run `npm install` in the root scenery directory
++ Run `npm install` in the root Scenery directory
 + If you are not running on an EC2 instance, and you wish to run validations
 on your CloudFormation templates, you must add your AWS credentials to a file
 `config.json`:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The entire [AWS CloudFormation API](http://docs.aws.amazon.com/AWSCloudFormation
 is available for use in Scenery, thanks to the [Scenery Generator](https://github.com/OpenWhere/scenery_generator)
 project, which generates Scenery classes from the Cloudformation docs.
 
-Please see the [examples](#TODO) folder for sample Scenery templates and the
+Please see the [examples](https://github.com/OpenWhere/scenery/tree/master/examples) folder for sample Scenery templates and the
 resulting CloudFormation template.
 
 ## Setup
@@ -33,7 +33,7 @@ for more information on this topic.
     - Run unit tests to make sure everything is passing correctly
 
 ## Building CloudFormation Templates
-To get started quickly, please see the [examples](#TODO)
+To get started quickly, please see the [examples](https://github.com/OpenWhere/scenery/tree/master/examples)
 folder for sample Scenery templates and the resulting CloudFormation template.
 
 Building CloudFormation templates can be boiled down into four basic steps:
@@ -73,39 +73,12 @@ t.addResource(i);
 // Write out the CloudFormation template
 t.save('ex1.json');
 ```
-The [resulting CloudFormation Template](#TODO)
+The [resulting CloudFormation Template](https://github.com/OpenWhere/scenery/tree/master/examples/ex1.json)
 is nearly twice as long and much less readable.
 
-Check out some more complex templates in the [examples](#TODO) folder.
+Check out some more complex templates in the [examples](https://github.com/OpenWhere/scenery/tree/master/examples/) folder.
 
-## Modifying Existing Cloudformation Templates
-To load an existing CloudFormation template from JSON into Scenery objects,
-invoke the `Template.parse()` function. For example:
-
-```javascript
-var myTemplate = Template.parse('/path/to/your/cf/template.JSON');
-```
-
-Once you've loaded objects into memory, you can reference them by their AWS
-type using the template object's `getResourcesByType` function:
-
-```javascript
-var myTemplate = Template.parse('/path/to/your/cf/template.JSON');
-var ec2Instances = myTemplate.getResourcesByType('AWS::EC2::Instance');
-
-// The ec2Instances var is an array of Scenery Instance objects
-var firstEc2Instance = ec2Instances[0];
-```
-
-Now that you have access to individual resources, you can modify them with
-standard Scenery functions. Save the template again to see the difference!
-
-
-## Example Workflow
-Below is an example workflow that highlights Scenery's ability to modify
-Cloudformation templates.
-
-### Modifying Existing Cloudformation Template
+## Modifying Existing Cloudformation Template
 Load and modify the template we created above:
 
 ```javascript
@@ -146,7 +119,7 @@ with the exception of our single EC2 instance:
 ...
 ```
 
-### Deleting Cloudformation Template Resources
+## Deleting Cloudformation Template Resources
 We can also remove resources from templates:
 
 ```javascript
@@ -201,7 +174,7 @@ and 2, but we deleted our once instances, so we have no Resources in the templat
 }
 ```
 
-#### Deleting Cloudformation Template Parameters
+## Deleting Cloudformation Template Parameters
 Similar to how we delete Resources, we can delete parameters from our Template
 object by invoking the `removeParameterByKey` function. Let's say we have the
 following CF Template with three parameters:

--- a/examples/ex1.js
+++ b/examples/ex1.js
@@ -1,0 +1,26 @@
+/**
+ * Example 1: A simple Scenery template for creating a single EC2 instance
+ **/
+ 
+// Create a new template object
+var Template = require('../lib/Template.js');
+var t = new Template();
+
+// Add some string parameters to our template.
+t.strParam('keyName', 'demo', 'Name of an existing keypair to use for accessing the instance');
+t.strParam('image', 'ami-ecf9a184', 'ID of the AMI image to use');
+t.strParam('instanceType', 'm3.medium', 'The type of instance (compute capacity, etc.) to be created');
+
+// Create the AWS::EC2::Instance
+var Instance = require('../lib/EC2/Instance.js');
+var i = new Instance('InstanceId')
+                .addName('Example 1 Test Instance')
+                .ImageId(t.ref('image'))
+                .InstanceType(t.ref('instanceType'))
+                .KeyName(t.ref('keyName'));
+                
+// Add our instance to our template
+t.addResource(i);
+
+// Write out the CloudFormation template
+t.save('ex1.json');

--- a/examples/ex1.json
+++ b/examples/ex1.json
@@ -1,0 +1,46 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "",
+    "Parameters": {
+        "keyName": {
+            "Type": "String",
+            "Description": "Name of an existing keypair to use for accessing the instance",
+            "Default": "demo"
+        },
+        "image": {
+            "Type": "String",
+            "Description": "ID of the AMI image to use",
+            "Default": "ami-ecf9a184"
+        },
+        "instanceType": {
+            "Type": "String",
+            "Description": "The type of instance (compute capacity, etc.) to be created",
+            "Default": "m3.medium"
+        }
+    },
+    "Mappings": {},
+    "Conditions": {},
+    "Resources": {
+        "InstanceId": {
+            "Type": "AWS::EC2::Instance",
+            "Properties": {
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "Example 1 Test Instance"
+                    }
+                ],
+                "ImageId": {
+                    "Ref": "image"
+                },
+                "InstanceType": {
+                    "Ref": "instanceType"
+                },
+                "KeyName": {
+                    "Ref": "keyName"
+                }
+            }
+        }
+    },
+    "Outputs": {}
+}

--- a/examples/ex2.js
+++ b/examples/ex2.js
@@ -1,0 +1,20 @@
+/**
+ * Example 2: Modify the instance we created in Example 1
+ **/
+ 
+var Template = require('../lib/Template.js');
+
+// Read in the CloudFormation JSON file
+var t2 = Template.parse('./ex1.json');
+
+// Find all the AWS::EC2::Instances in the template
+var ec2Instances = t2.getResourcesByType('AWS::EC2::Instance');
+
+// Modify the the first (and only) instance in the template
+var i2 = ec2Instances[0];
+i2.addName('Example 2 Test Instance');  // Modify the image name
+i2.ImageId('ami-000000');         // Modify the ImageId
+i2.InstanceType('t1.micro');      // Add an InstanceType
+
+// Save our modified template
+t2.save('ex2.json');

--- a/examples/ex2.json
+++ b/examples/ex2.json
@@ -1,0 +1,42 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "",
+    "Parameters": {
+        "keyName": {
+            "Type": "String",
+            "Description": "Name of an existing keypair to use for accessing the instance",
+            "Default": "demo"
+        },
+        "image": {
+            "Type": "String",
+            "Description": "ID of the AMI image to use",
+            "Default": "ami-ecf9a184"
+        },
+        "instanceType": {
+            "Type": "String",
+            "Description": "The type of instance (compute capacity, etc.) to be created",
+            "Default": "m3.medium"
+        }
+    },
+    "Mappings": {},
+    "Conditions": {},
+    "Resources": {
+        "InstanceId": {
+            "Type": "AWS::EC2::Instance",
+            "Properties": {
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "Example 2 Test Instance"
+                    }
+                ],
+                "ImageId": "ami-000000",
+                "InstanceType": "t1.micro",
+                "KeyName": {
+                    "Ref": "keyName"
+                }
+            }
+        }
+    },
+    "Outputs": {}
+}

--- a/examples/ex3.js
+++ b/examples/ex3.js
@@ -1,0 +1,18 @@
+/**
+ * Example 3: Delete the instance we created in Example 1 and modified in Example 2
+ **/
+ 
+var Template = require('../lib/Template.js');
+
+// Read in the CloudFormation JSON file
+var t3 = Template.parse('./ex2.json');
+
+// Find all the AWS::EC2::Instances in the template
+var ec2Instances = t3.getResourcesByType('AWS::EC2::Instance');
+
+// Get the logical ID of our one EC2 instance
+var logicalId = ec2Instances[0].id;
+t3.removeResourceByKey(logicalId);
+
+// Save our modified template
+t3.save('ex3.json');

--- a/examples/ex3.json
+++ b/examples/ex3.json
@@ -1,0 +1,25 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "",
+    "Parameters": {
+        "keyName": {
+            "Type": "String",
+            "Description": "Name of an existing keypair to use for accessing the instance",
+            "Default": "demo"
+        },
+        "image": {
+            "Type": "String",
+            "Description": "ID of the AMI image to use",
+            "Default": "ami-ecf9a184"
+        },
+        "instanceType": {
+            "Type": "String",
+            "Description": "The type of instance (compute capacity, etc.) to be created",
+            "Default": "m3.medium"
+        }
+    },
+    "Mappings": {},
+    "Conditions": {},
+    "Resources": {},
+    "Outputs": {}
+}

--- a/lib/Taggable.js
+++ b/lib/Taggable.js
@@ -33,6 +33,15 @@ Taggable.prototype.addTag = function (key, value) {
     if (!(this.node.Properties.Tags instanceof Array)) {
         this.node.Properties.Tags = [];
     }
+
+    //  If tag exists, remove original before adding updated version
+    var existingTag = _.find(this.node.Properties.Tags, function(tag){
+        return tag.Key === key;
+    });
+    if (existingTag){
+        this.node.Properties.Tags = _.without(this.node.Properties.Tags, existingTag);
+    }
+
     this.node.Properties.Tags.push({'Key': key, 'Value': value ||''});
     return this;
 };

--- a/test/convenienceFunctionsTest.js
+++ b/test/convenienceFunctionsTest.js
@@ -47,10 +47,10 @@ exports.testEasyUserData = function(test) {
             'echo "valid test"'
         ];
         var expectedUserData =  { 
-         'Fn::Base64' : { 
-            'Fn::Join' : [ '', commands ] 
-         }
-     };
+            'Fn::Base64' : {
+                'Fn::Join' : [ '', commands ]
+            }
+        };
         i3.easyUserData(commands);
         test.deepEqual(expectedUserData, i3.node.Properties.UserData);
     });

--- a/test/taggableTest.js
+++ b/test/taggableTest.js
@@ -24,6 +24,18 @@ exports.TaggableTypeTest = function(test){
     test.done();
 };
 
+exports.OverwriteTagTest = function(test){
+    var taggable = new Taggable('taggableResource');
+    taggable.addTag('testKey', 'failure');
+    taggable.addTag('testKey', 'success');
+
+    test.expect(2);
+    var myTags = taggable.getTags();
+    test.ok(myTags.length === 1);
+    test.ok(myTags[0].Value === 'success');
+    test.done();
+};
+
 exports.NameableTest = function(test){
     var notTaggable = new Resource('notTaggableResource');
     var taggable = new Taggable('taggableResource');


### PR DESCRIPTION
By adding an introduction to the README and adding a folder of examples, we hope to make Scenery much more approachable for beginners.

I also snuck in a quick enhancement/bugfix: adding a tag to a Taggable resource that already has a tag with the same key used to add a second tag with a duplicate key. Now, it replaces the first tag with the new one.