### PR TITLE
Promisify userDataFromFile; add associated tests

### DIFF
--- a/lib/convenience/AWS::EC2::Instance.js
+++ b/lib/convenience/AWS::EC2::Instance.js
@@ -1,5 +1,6 @@
 'use strict';
-var fs = require('fs');
+var BlueBird = require('bluebird');
+var fs = BlueBird.promisifyAll(require('fs'));
 
 function Instance() { }
 /**
@@ -27,7 +28,7 @@ Instance.prototype.easyUserData = function(arrayOfCommands) {
      return this;
 };
 
-Instance.prototype.userDataFromFile = function(path, callback) {
+Instance.prototype.userDataFromFileCallback = function(path, callback) {
     /**
      * This function accepts a path to a file that will be parsed,
      * converted to an array, and stored in the UserData function.
@@ -54,6 +55,30 @@ Instance.prototype.userDataFromFile = function(path, callback) {
     };
     fs.readFile(path, 'utf-8', installUserData);
     return this;
+};
+
+Instance.prototype.userDataFromFile = function(path) {
+    /**
+     * This function uses promises to asynchronously read the contents of the
+     * file specified in the `path` variable and return the instance object with
+     * the file contents in the UserData section of the EC2::Instance object.
+     **/
+     var self = this;
+     return fs.readFileAsync(path, 'utf-8')
+        .then(function(data){
+            var arrayOfCommands = data.toString().split(/(\n)/g);
+            var userData = {
+                'Fn::Base64' : {
+                   'Fn::Join' : [ '', arrayOfCommands ]
+                }
+            };
+            self.node.Properties.UserData = userData;
+            return self;
+        })
+        .catch(function(error){
+            //console.error('Error reading UserData from file:', error);
+            return self;
+        });
 };
 
 module.exports = Instance;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "async": "0.9.0",
     "aws-sdk": "2.1.26",
+    "bluebird": "^2.9.26",
     "lodash": "3.7.0",
     "modelo": "4.1.2",
     "walk": "2.3.4"

--- a/test/AWS_EC2_Instance_Convenience_Test.js
+++ b/test/AWS_EC2_Instance_Convenience_Test.js
@@ -2,6 +2,56 @@
 var fs = require('fs');
 
 exports.testUserDataFromFile = function(test) {
+    test.expect(3);
+
+    var Instance = require('../lib/EC2/Instance.js');
+    var i = new Instance();
+    test.ok(i.userDataFromFile);            // Assert the function exists
+    test.ok(!i.node.Properties.UserData);   // Assert we don't already have data
+
+    // Fetch the data
+    i.userDataFromFile(__dirname + '/userDataSample.sh').then(function(){
+        test.ok(i.node.Properties.UserData);    // Assert we now have data
+        test.done();                            // Wrap up the test
+    });
+};
+// TODO: We may also wish to add tests asserting that the UserData
+// section matches the contents of the file passed to the function.
+
+exports.testUserDataFromInvalidFile = function(test) {
+    test.expect(3);
+    var Instance = require('../lib/EC2/Instance.js');
+    var i = new Instance();
+    test.ok(i.userDataFromFile);            // Assert the function exists
+    test.ok(!i.node.Properties.UserData);   // Assert we don't already have data
+
+    // Fetch the data
+    i.userDataFromFile(__dirname + '/invalidFile.sh').then(function(){
+        test.ok(!i.node.Properties.UserData);   // Assert we still have no data
+        test.done();                            // Wrap up the test
+    });
+};
+
+exports.testUserDataFromFileIsFluent = function(test) {
+    test.expect(5);
+    var Instance = require('../lib/EC2/Instance.js');
+    var i = new Instance();
+    test.ok(i.userDataFromFile);            // Assert the function exists
+    test.ok(!i.node.Properties.UserData);   // Assert we don't already have data
+
+    i.KeyName('TestKey')
+    .ImageId('TestImageId')
+    .userDataFromFile(__dirname + '/userDataSample.sh').then(function(){
+        test.ok(i.node.Properties.KeyName);
+        test.ok(i.node.Properties.ImageId);
+        test.ok(i.node.Properties.UserData);    // Assert we now have data
+        test.done();                            // Wrap up the test
+    });
+    // TODO: This is not fluent, unfortunately, because Promises.
+    // We'll need to wait until ES7 and `await`
+};
+
+exports.testUserDataFromFileCallbackVer = function(test) {
     test.expect(5);
 
     var Instance = require('../lib/EC2/Instance.js');
@@ -25,12 +75,8 @@ exports.testUserDataFromFile = function(test) {
             );
             test.done();
         };
-
         fs.readFile(__dirname + '/userDataSample.sh', assertFileContentsEqual);
+
     };
-
-    i.userDataFromFile(__dirname + '/userDataSample.sh', callback);
+    i.userDataFromFileCallback(__dirname + '/userDataSample.sh', callback);
 };
-
-// TODO: We may also wish to add tests asserting that the UserData
-// section matches the contents of the file passed to the function.


### PR DESCRIPTION
The `userDataFromFile` convenience function now reads files through the magic of promises, rather than through callbacks.

The old callback-based `userDataFromFile` function has been renamed to `userDataFromFileCallback`.

The only downside to this is that this function is not fluent because it returns promises and not the result of the promise, but as long as `userDataFromFile` is the last function invoked, this should not be a problem.  See the tests for details.